### PR TITLE
Switch to UUID for identifying completed tasks

### DIFF
--- a/task-gantt
+++ b/task-gantt
@@ -54,7 +54,9 @@ for my $task (@task_hierarchy) {
 	my $start = $due_date - 24*60*60 * $duration;
 	my $end   = $due_date;
 
-	my $resource = $gc->addResource(name => $task->{id});
+	my $id = $task->{id} || $task->{uuid};
+
+	my $resource = $gc->addResource(name => $id);
 	$gc->addTask(
 		description => $task->{description},
 		resource    => $resource,


### PR DESCRIPTION
The task id was used for the resource name in Project::Gantt. This works
for pending tasks, but completed tasks have id 0, which doesn't work (is
not unique, and there also seems to be a bug in Project::Gantt where it
evaluates the name as a boolean to check it is defined, which returns
false for 0).

Pending tasks will still use their task id, but completed tasks will
show their uuid instead.
